### PR TITLE
Gcc 4.6 fixes

### DIFF
--- a/makefile
+++ b/makefile
@@ -99,7 +99,7 @@ CFLAGS=-Wall -O3 -Iinclude -Ilib/lcfg
 LDFLAGS=
 
 CFLAGS+=-fdata-sections -ffunction-sections
-LDFLAGS+=-Wl,--gc-sections -Wl,--print-gc-sections
+LDFLAGS+=-Wl,--gc-sections -Wl,--print-gc-sections -Wl,--no-print-gc-sections
 LDFLAGS_USB=-lusb
 
 CROSS_CC ?=$(CROSS_COMPILE)gcc


### PR DESCRIPTION
omap-u-boot-utils does not compile with gcc 4.6, due to more strict checking of commandline options.

My gcc-4.6-fixes branch has the changes needed to get it compile again.

These changes have been tested using both gcc 4.6 and gcc 4.5.

Luca
