### PR TITLE
proper cleanup flags for MacOSX.

### DIFF
--- a/makefile
+++ b/makefile
@@ -102,7 +102,11 @@ CFLAGS=-Wall -O3 -Iinclude -Ilib/lcfg
 LDFLAGS=
 
 CFLAGS+=-fdata-sections -ffunction-sections
+ifeq ($(HOSTOS),darwin)
+LDFLAGS+=-Wl,-dead_strip
+else
 LDFLAGS+=-Wl,--gc-sections -Wl,--print-gc-sections -Wl,--no-print-gc-sections
+endif
 # should usually produce -lusb-1.0
 LDFLAGS_USB=`pkg-config libusb-1.0 --libs`
 


### PR DESCRIPTION
There is no --gc-sections on MacOSX, so use the equivalent
flag which also results in binary size reduction.

Signed-off-by: Andreas Kemnade <andreas@kemnade.info>